### PR TITLE
Change SetJustifyV("CENTER") -> SetJustifyV("MIDDLE").

### DIFF
--- a/Dependencies/UIFactory.lua
+++ b/Dependencies/UIFactory.lua
@@ -19,7 +19,7 @@ end
 function FiveSecondRule.UIFactory:MakeText(parent, text, size)
     local text_obj = parent:CreateFontString(nil, "ARTWORK")
     text_obj:SetFont("Fonts/FRIZQT__.ttf", size)
-    text_obj:SetJustifyV("CENTER")
+    text_obj:SetJustifyV("MIDDLE")
     text_obj:SetJustifyH("CENTER")
     text_obj:SetText(text)
     return text_obj
@@ -43,7 +43,7 @@ function FiveSecondRule.UIFactory:MakeEditBox(name, parent, title, w, h, enter_f
     edit_box_obj:SetAutoFocus(false)
     edit_box_obj:SetMaxLetters(4)
     edit_box_obj:SetJustifyH("CENTER")
-	edit_box_obj:SetJustifyV("CENTER")
+    edit_box_obj:SetJustifyV("MIDDLE")
     edit_box_obj:SetFontObject(GameFontNormal)
     edit_box_obj:SetScript("OnEnterPressed", function(self)
         enter_func(self)


### PR DESCRIPTION
The Classic Era now is up to date with almost retail: https://warcraft.wiki.gg/wiki/Patch_10.2.7/API_changes.

The error that throws up:
```
Message: ...ace/AddOns/FiveSecondRule/Dependencies/UIFactory.lua:22: bad argument #1 to 'SetJustifyV' (Usage: self:SetJustifyV(justifyV))
Time: Sat Jul 13 15:23:02 2024
Count: 1
Stack: ...ace/AddOns/FiveSecondRule/Dependencies/UIFactory.lua:22: bad argument #1 to 'SetJustifyV' (Usage: self:SetJustifyV(justifyV))
[string "=[C]"]: ?
[string "=[C]"]: in function `SetJustifyV'
[string "@Interface/AddOns/FiveSecondRule/Dependencies/UIFactory.lua"]:22: in function `MakeText'
[string "@Interface/AddOns/FiveSecondRule/Dependencies/UIFactory.lua"]:30: in function `MakeEditBox'
[string "@Interface/AddOns/FiveSecondRule/Modules/OptionsPanel.lua"]:196: in function `CreateGUI'
[string "@Interface/AddOns/FiveSecondRule/Modules/OptionsPanel.lua"]:20: in function <...rface/AddOns/FiveSecondRule/Modules/OptionsPanel.lua:17>

Locals: (*temporary) = <function> defined =[C]:-1
```