### PR TITLE
Fix changes from API for new 1.15.3 Classic version.

### DIFF
--- a/Dependencies/UIFactory.lua
+++ b/Dependencies/UIFactory.lua
@@ -1,4 +1,4 @@
-FiveSecondRule.UIFactory = {} 
+FiveSecondRule.UIFactory = {}
 
 function FiveSecondRule.UIFactory:MakeCheckbox(name, parent, tooltip_text)
     local cb = CreateFrame("CheckButton", name, parent, "UICheckButtonTemplate")
@@ -19,7 +19,7 @@ end
 function FiveSecondRule.UIFactory:MakeText(parent, text, size)
     local text_obj = parent:CreateFontString(nil, "ARTWORK")
     text_obj:SetFont("Fonts/FRIZQT__.ttf", size)
-    text_obj:SetJustifyV("CENTER")
+    text_obj:SetJustifyV("MIDDLE")
     text_obj:SetJustifyH("CENTER")
     text_obj:SetText(text)
     return text_obj
@@ -43,7 +43,7 @@ function FiveSecondRule.UIFactory:MakeEditBox(name, parent, title, w, h, enter_f
     edit_box_obj:SetAutoFocus(false)
     edit_box_obj:SetMaxLetters(4)
     edit_box_obj:SetJustifyH("CENTER")
-	edit_box_obj:SetJustifyV("CENTER")
+	edit_box_obj:SetJustifyV("MIDDLE")
     edit_box_obj:SetFontObject(GameFontNormal)
     edit_box_obj:SetScript("OnEnterPressed", function(self)
         enter_func(self)
@@ -63,7 +63,7 @@ function FiveSecondRule.UIFactory:MakeButton(name, parent, width, height, text, 
     return button
 end
 
-function FiveSecondRule.UIFactory:MakeColor(r,g,b,a) 
+function FiveSecondRule.UIFactory:MakeColor(r,g,b,a)
     return {r = r, g = g, b = b, a = a}
 end
 
@@ -91,7 +91,7 @@ end
 function FiveSecondRule.UIFactory:ShowColorPicker(r, g, b, a, changedCallback)
     ColorPickerFrame:SetColorRGB(r,g,b);
     ColorPickerFrame.hasOpacity = (a ~= nil);
-    
+
     if (ColorPickerFrame.hasOpacity) then
         ColorPickerFrame.opacity = a
         OpacitySliderFrame:SetValue(a) -- the value is not set automatically by the ColorPickerFrame
@@ -101,7 +101,7 @@ function FiveSecondRule.UIFactory:ShowColorPicker(r, g, b, a, changedCallback)
 
     ColorPickerFrame.func = changedCallback
 
-    ColorPickerFrame:SetScript("OnShow", function () 
+    ColorPickerFrame:SetScript("OnShow", function ()
         FiveSecondRule:Unlock();
 
         -- Add callbacks when the color picker is shown, since they might have been removed from previous use
@@ -109,7 +109,7 @@ function FiveSecondRule.UIFactory:ShowColorPicker(r, g, b, a, changedCallback)
         ColorPickerFrame.opacityFunc = changedCallback
     end)
 
-    ColorPickerFrame:SetScript("OnHide", function () 
+    ColorPickerFrame:SetScript("OnHide", function ()
         FiveSecondRule:Lock();
 
         -- Remove callbacks to avoid leaking callbacks when using multiple color pickers
@@ -122,9 +122,9 @@ function FiveSecondRule.UIFactory:ShowColorPicker(r, g, b, a, changedCallback)
 
 end
 
-function FiveSecondRule.UIFactory:UnpackColor(restore) 
+function FiveSecondRule.UIFactory:UnpackColor(restore)
     local newR, newG, newB, newA
-            
+
     if restore then
      newR, newG, newB, newA = unpack(restore)
     else

--- a/Modules/SlashCommands.lua
+++ b/Modules/SlashCommands.lua
@@ -1,5 +1,5 @@
 -- COMMANDS
-SLASH_FSR1 = '/fsr'; 
+SLASH_FSR1 = '/fsr';
 
 function SlashCmdList.FSR(msg, editbox)
     local cmd = msg:lower()
@@ -18,13 +18,13 @@ function SlashCmdList.FSR(msg, editbox)
         print("Five Second Rule - RESET ALL SETTINGS")
         FiveSecondRule:Reset()
     end
-    
+
     if cmd == "enable" or cmd == "enabled" then
         print("Five Second Rule - ENABLED")
         FiveSecondRule_Options.enabled = true
         FiveSecondRule:Refresh()
     end
-    
+
     if cmd == "disable" or cmd == "disabled" then
         print("Five Second Rule - DISABLED")
         FiveSecondRule_Options.enabled = false
@@ -32,7 +32,6 @@ function SlashCmdList.FSR(msg, editbox)
     end
 
     if cmd == "" or cmd == "help" then
-        FiveSecondRule:PrintHelp()  
-        InterfaceOptionsFrame_OpenToCategory(FiveSecondRule.OptionsPanelFrame)
+        InterfaceOptionsFrame_OpenToCategory(FiveSecondRule.OptionsPanelFrame.optionsPanel.title:GetText())
     end
 end


### PR DESCRIPTION
The Classic Era now is up to date with almost retail: https://warcraft.wiki.gg/wiki/Patch_10.2.7/API_changes.

1) The enforce of input to `SetJustifyV` function.

The error that throws up:
```
Message: ...ace/AddOns/FiveSecondRule/Dependencies/UIFactory.lua:22: bad argument #1 to 'SetJustifyV' (Usage: self:SetJustifyV(justifyV))
Time: Sat Jul 13 15:23:02 2024
Count: 1
Stack: ...ace/AddOns/FiveSecondRule/Dependencies/UIFactory.lua:22: bad argument #1 to 'SetJustifyV' (Usage: self:SetJustifyV(justifyV))
[string "=[C]"]: ?
[string "=[C]"]: in function `SetJustifyV'
[string "@Interface/AddOns/FiveSecondRule/Dependencies/UIFactory.lua"]:22: in function `MakeText'
[string "@Interface/AddOns/FiveSecondRule/Dependencies/UIFactory.lua"]:30: in function `MakeEditBox'
[string "@Interface/AddOns/FiveSecondRule/Modules/OptionsPanel.lua"]:196: in function `CreateGUI'
[string "@Interface/AddOns/FiveSecondRule/Modules/OptionsPanel.lua"]:20: in function <...rface/AddOns/FiveSecondRule/Modules/OptionsPanel.lua:17>

Locals: (*temporary) = <function> defined =[C]:-1
```

2) How to open the Addon Seetings pannel, a long standing bug https://github.com/Stanzilla/WoWUIBugs/issues/89

3) Removal of function `PrintHelp` from code and leaving reference to it: [Disable login message and remove the print message when using the /fsr command.](https://github.com/smp4903/FiveSecondRule/commit/1b64902b9b770d7d2ecd23ede2ada03bba20636a)
```
Message: ...face/AddOns/FiveSecondRule/Modules/SlashCommands.lua:35: attempt to call method 'PrintHelp' (a nil value)
Time: Sun Jul 14 07:54:57 2024
Count: 1
Stack: ...face/AddOns/FiveSecondRule/Modules/SlashCommands.lua:35: attempt to call method 'PrintHelp' (a nil value)
[string "@Interface/AddOns/FiveSecondRule/Modules/SlashCommands.lua"]:35: in function ?' [string "@Interface/AddOns/Blizzard_ChatFrameBase/Classic/ChatFrame.lua"]:5016: in function ChatEdit_ParseText'
[string "@Interface/AddOns/Blizzard_ChatFrameBase/Classic/ChatFrame.lua"]:4674: in function ChatEdit_SendText' [string "@Interface/AddOns/Blizzard_ChatFrameBase/Classic/ChatFrame.lua"]:4710: in function ChatEdit_OnEnterPressed'
[string "*ChatFrame.xml:120_OnEnterPressed"]:1: in function <[string "*ChatFrame.xml:120_OnEnterPressed"]:1>
```
